### PR TITLE
Add overrides to RequireManagement for more flexible configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ run as a standalone plugin or as a rule with the maven-enforcer-plugin.
             <allowExclusions>false</allowExclusions>
             <overrides>
               <override>
-                <exceptions>
-                  <exception>com.example:*</exception>
-                </exceptions>
+                <patterns>
+                  <pattern>com.example:*</pattern>
+                </patterns>
                 <dependencies>false</dependencies>
               </override>
             </overrides>

--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ run as a standalone plugin or as a rule with the maven-enforcer-plugin.
             <plugins>true</plugins>
             <allowVersions>false</allowVersions>
             <allowExclusions>false</allowExclusions>
-            <exceptions>
-              <exception>com.example:*</exception>
-            </exceptions>
+            <overrides>
+              <override>
+                <exceptions>
+                  <exception>com.example:*</exception>
+                </exceptions>
+                <dependencies>false</dependencies>
+              </override>
+            </overrides>
           </requireManagement>
         </configuration>
       </execution>

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
@@ -126,7 +126,6 @@ public class DependencyManagementAnalyzer {
     for (RequireManagementOverride override : requireManagement.getOverrides()) {
       for (String exception : override.getExceptions()) {
         if (SelectorUtils.match(exception, key)) {
-          System.out.println("Using override:" + override);
           return override.toRequireManagementConfig(requireManagement);
         }
       }

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
@@ -124,8 +124,8 @@ public class DependencyManagementAnalyzer {
       key = key.substring(0, key.indexOf(':', key.indexOf(':') + 1));
     }
     for (RequireManagementOverride override : requireManagement.getOverrides()) {
-      for (String exception : override.getExceptions()) {
-        if (SelectorUtils.match(exception, key)) {
+      for (String pattern : override.getPatterns()) {
+        if (SelectorUtils.match(pattern, key)) {
           return override.toRequireManagementConfig(requireManagement);
         }
       }

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagement.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagement.java
@@ -3,13 +3,14 @@ package com.hubspot.maven.plugins.dependency.management;
 import java.util.ArrayList;
 import java.util.List;
 
-public class RequireManagement {
+public class RequireManagement implements RequireManagmentConfig {
   private boolean dependencies = false;
   private boolean plugins = false;
   private boolean allowVersions = true;
   private boolean allowExclusions = true;
-  private List<String> exceptions = new ArrayList<>();
+  private List<RequireManagementOverride> overrides = new ArrayList<>();
 
+  @Override
   public boolean requireDependencyManagement() {
     return dependencies;
   }
@@ -18,6 +19,7 @@ public class RequireManagement {
     this.dependencies = dependencies;
   }
 
+  @Override
   public boolean requirePluginManagement() {
     return plugins;
   }
@@ -26,6 +28,7 @@ public class RequireManagement {
     this.plugins = plugins;
   }
 
+  @Override
   public boolean allowVersions() {
     return allowVersions;
   }
@@ -34,6 +37,7 @@ public class RequireManagement {
     this.allowVersions = allowVersions;
   }
 
+  @Override
   public boolean allowExclusions() {
     return allowExclusions;
   }
@@ -42,11 +46,11 @@ public class RequireManagement {
     this.allowExclusions = allowExclusions;
   }
 
-  public List<String> getExceptions() {
-    return exceptions;
+  public List<RequireManagementOverride> getOverrides() {
+    return overrides;
   }
 
-  public void setExceptions(List<String> exceptions) {
-    this.exceptions = exceptions;
+  public void setOverrides(List<RequireManagementOverride> overrides) {
+    this.overrides = overrides;
   }
 }

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
@@ -4,18 +4,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RequireManagementOverride {
-  private List<String> exceptions = new ArrayList<>();
+  private List<String> patterns = new ArrayList<>();
   private Boolean dependencies = null;
   private Boolean plugins = null;
   private Boolean allowVersions = null;
   private Boolean allowExclusions = null;
 
-  public List<String> getExceptions() {
-    return exceptions;
+  public List<String> getPatterns() {
+    return patterns;
   }
 
-  public void setExceptions(List<String> exceptions) {
-    this.exceptions = exceptions;
+  public void setPatterns(List<String> patterns) {
+    this.patterns = patterns;
   }
 
   public void setDependencies(boolean dependencies) {

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
@@ -1,0 +1,64 @@
+package com.hubspot.maven.plugins.dependency.management;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RequireManagementOverride {
+  private List<String> exceptions = new ArrayList<>();
+  private Boolean dependencies = null;
+  private Boolean plugins = null;
+  private Boolean allowVersions = null;
+  private Boolean allowExclusions = null;
+
+  public List<String> getExceptions() {
+    return exceptions;
+  }
+
+  public void setExceptions(List<String> exceptions) {
+    this.exceptions = exceptions;
+  }
+
+  public void setDependencies(boolean dependencies) {
+    this.dependencies = dependencies;
+  }
+
+  public void setPlugins(boolean plugins) {
+    this.plugins = plugins;
+  }
+
+  public void setAllowVersions(boolean allowVersions) {
+    this.allowVersions = allowVersions;
+  }
+
+  public void setAllowExclusions(boolean allowExclusions) {
+    this.allowExclusions = allowExclusions;
+  }
+
+  public RequireManagmentConfig toRequireManagementConfig(final RequireManagement requireManagement) {
+    return new RequireManagmentConfig() {
+      @Override
+      public boolean requireDependencyManagement() {
+        return fallbackIfNull(dependencies, requireManagement.requireDependencyManagement());
+      }
+
+      @Override
+      public boolean requirePluginManagement() {
+        return fallbackIfNull(plugins, requireManagement.requirePluginManagement());
+      }
+
+      @Override
+      public boolean allowVersions() {
+        return fallbackIfNull(allowVersions, requireManagement.allowVersions());
+      }
+
+      @Override
+      public boolean allowExclusions() {
+        return fallbackIfNull(allowExclusions, requireManagement.allowExclusions());
+      }
+    };
+  }
+
+  private static boolean fallbackIfNull(Boolean b1, boolean b2) {
+    return b1 != null ? b1 : b2;
+  }
+}

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagmentConfig.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagmentConfig.java
@@ -1,0 +1,8 @@
+package com.hubspot.maven.plugins.dependency.management;
+
+public interface RequireManagmentConfig {
+  boolean requireDependencyManagement();
+  boolean requirePluginManagement();
+  boolean allowVersions();
+  boolean allowExclusions();
+}


### PR DESCRIPTION
This should allow for more flexible configuration of this plugin. Our use case, is not requiring management and allowing versions for all `com.hubspot*` stuff.

@jhaber 