### PR TITLE
Added custom error messages for dependency and plugin issues

### DIFF
--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
@@ -15,8 +15,12 @@ public class DependencyManagementAnalyzer {
   private final MavenProject project;
   private final RequireManagement requireManagement;
   private final Log log;
-  private boolean dependencyversionMismatchError = false, unManagedDependencyError = false, unManagedPluginError = false,
-  pluginversionMismatchError = false, dependencyExclusionsError = false, dependencyVersionDisallowed = false;
+  private boolean dependencyversionMismatchError = false;
+  private boolean unmanagedDependencyError = false;
+  private boolean unmanagedPluginError = false;
+  private boolean pluginversionMismatchError = false;
+  private boolean dependencyExclusionsError = false;
+  private boolean dependencyVersionDisallowed = false;
 
 
   public DependencyManagementAnalyzer(MavenProject project, RequireManagement requireManagement, Log log) {
@@ -30,12 +34,22 @@ public class DependencyManagementAnalyzer {
     // don't combine with previous line, we don't want short-circuit evaluation
     success &= checkPluginManagement();
     log.info("\n\n---- Issues found ----\n");
-    if (unManagedDependencyError) { log.warn(requireManagement.unManagedDependencyMessage()); }
-    if (dependencyversionMismatchError) { log.warn(requireManagement.dependencyVersionMismatchMessage()); }
-    if (unManagedPluginError) { log.warn(requireManagement.unManagedPluginMessage()); }
-    if (pluginversionMismatchError) { log.warn(requireManagement.pluginVersionMismatchMessage()); }
-    if (dependencyExclusionsError) { log.warn(requireManagement.dependencyExclusionsMessage()); }
-    if (dependencyVersionDisallowed) { log.warn(requireManagement.dependencyVersionDisallowedMessage()); }
+    if (unmanagedDependencyError) {
+      log.warn(requireManagement.unmanagedDependencyMessage());
+    }
+    if (dependencyversionMismatchError) {
+      log.warn(requireManagement.dependencyVersionMismatchMessage());
+    }
+    if (unmanagedPluginError) {
+      log.warn(requireManagement.unmanagedPluginMessage()); }
+    if (pluginversionMismatchError) {
+      log.warn(requireManagement.pluginVersionMismatchMessage());
+    }
+    if (dependencyExclusionsError) {
+      log.warn(requireManagement.dependencyExclusionsMessage()); }
+    if (dependencyVersionDisallowed) {
+      log.warn(requireManagement.dependencyVersionDisallowedMessage());
+    }
     return success;
   }
 
@@ -74,7 +88,7 @@ public class DependencyManagementAnalyzer {
         }
       } else if (config.requireDependencyManagement()) {
         log.warn(String.format("Dependency %s is not managed", dependencyKey));
-        unManagedDependencyError = true;
+        unmanagedDependencyError = true;
         success = false;
       }
     }
@@ -101,7 +115,7 @@ public class DependencyManagementAnalyzer {
         }
       } else if (config.requirePluginManagement()) {
         log.warn(String.format("Plugin %s is not managed", projectPlugin.getKey()));
-        unManagedPluginError = true;
+        unmanagedPluginError = true;
         success = false;
       }
     }

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
@@ -1,5 +1,6 @@
 package com.hubspot.maven.plugins.dependency.management;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +22,8 @@ public class DependencyManagementAnalyzer {
   private boolean pluginVersionMismatchError = false;
   private boolean dependencyExclusionsError = false;
   private boolean dependencyVersionDisallowedError = false;
+  private ArrayList<String> errorMessages = new ArrayList<String>();
+  //private String[] errorMessages;
 
   public DependencyManagementAnalyzer(MavenProject project, RequireManagement requireManagement, Log log) {
     this.project = project;
@@ -33,25 +36,32 @@ public class DependencyManagementAnalyzer {
     // don't combine with previous line, we don't want short-circuit evaluation
     success &= checkPluginManagement();
 
-    log.warn("");
-    if (unmanagedDependencyError) {
-      log.warn(requireManagement.unmanagedDependencyMessage());
+
+    if (errorMessages.size() > 0) {
+      log.warn("");
+      for(int msg = 0; msg < errorMessages.size(); msg++) {
+        log.warn(errorMessages.get(msg));
+      }
     }
-    if (dependencyVersionMismatchError) {
-      log.warn(requireManagement.dependencyVersionMismatchMessage());
+
+    /*if (unmanagedDependencyError && requireManagement.unmanagedDependencyMessage() != null) {
+      log.warn("Found unmanaged dependencies: "+requireManagement.unmanagedDependencyMessage());
     }
-    if (unmanagedPluginError) {
-      log.warn(requireManagement.unmanagedPluginMessage());
+    if (dependencyVersionMismatchError && requireManagement.dependencyVersionMismatchMessage() != null) {
+      log.warn("Found version mismatches in managed dependencies: "+requireManagement.dependencyVersionMismatchMessage());
     }
-    if (pluginVersionMismatchError) {
-      log.warn(requireManagement.pluginVersionMismatchMessage());
+    if (unmanagedPluginError && requireManagement.unmanagedPluginMessage() != null) {
+      log.warn("Found unmanaged plugins: "+requireManagement.unmanagedPluginMessage());
     }
-    if (dependencyExclusionsError) {
-      log.warn(requireManagement.dependencyExclusionsMessage());
+    if (pluginVersionMismatchError && requireManagement.pluginVersionMismatchMessage() != null) {
+      log.warn("Found version mismatches in plugins: "+requireManagement.pluginVersionMismatchMessage());
     }
-    if (dependencyVersionDisallowedError) {
-      log.warn(requireManagement.dependencyVersionDisallowedMessage());
+    if (dependencyExclusionsError && requireManagement.dependencyExclusionsMessage() != null) {
+      log.warn("Found exclusions in managed dependencies: "+requireManagement.dependencyExclusionsMessage());
     }
+    if (dependencyVersionDisallowedError && requireManagement.dependencyVersionDisallowedMessage() != null) {
+      log.warn("Found version in managed dependencies: "+requireManagement.dependencyVersionDisallowedMessage());
+    }*/
 
     return success;
   }
@@ -96,6 +106,18 @@ public class DependencyManagementAnalyzer {
       }
     }
 
+    if (dependencyVersionMismatchError && requireManagement.dependencyVersionMismatchMessage() != null) {
+      errorMessages.add("Found version mismatches in managed dependencies: "+requireManagement.dependencyVersionMismatchMessage());
+    }
+    if (dependencyVersionDisallowedError && requireManagement.dependencyVersionDisallowedMessage() != null) {
+      errorMessages.add("Found version in managed dependencies: "+requireManagement.dependencyVersionDisallowedMessage());
+    }
+    if (dependencyExclusionsError && requireManagement.dependencyExclusionsMessage() != null) {
+      errorMessages.add("Found exclusions in managed dependencies: "+requireManagement.dependencyExclusionsMessage());
+    }
+    if (unmanagedDependencyError && requireManagement.unmanagedDependencyMessage() != null) {
+      errorMessages.add("Found unmanaged dependencies: "+requireManagement.unmanagedDependencyMessage());
+    }
     return success;
   }
 
@@ -122,6 +144,12 @@ public class DependencyManagementAnalyzer {
         unmanagedPluginError = true;
         success = false;
       }
+    }
+    if (pluginVersionMismatchError && requireManagement.pluginVersionMismatchMessage() != null) {
+      errorMessages.add("Found version mismatches in plugins: "+requireManagement.pluginVersionMismatchMessage());
+    }
+    if (unmanagedPluginError && requireManagement.unmanagedPluginMessage() != null) {
+      errorMessages.add("Found unmanaged plugins: "+requireManagement.unmanagedPluginMessage());
     }
 
     return success;

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
@@ -20,7 +20,7 @@ public class DependencyManagementAnalyzer {
   private boolean unmanagedPluginError = false;
   private boolean pluginVersionMismatchError = false;
   private boolean dependencyExclusionsError = false;
-  private boolean dependencyVersionDisallowed = false;
+  private boolean dependencyVersionDisallowedError = false;
 
   public DependencyManagementAnalyzer(MavenProject project, RequireManagement requireManagement, Log log) {
     this.project = project;
@@ -49,7 +49,7 @@ public class DependencyManagementAnalyzer {
     if (dependencyExclusionsError) {
       log.warn(requireManagement.dependencyExclusionsMessage());
     }
-    if (dependencyVersionDisallowed) {
+    if (dependencyVersionDisallowedError) {
       log.warn(requireManagement.dependencyVersionDisallowedMessage());
     }
 
@@ -79,7 +79,7 @@ public class DependencyManagementAnalyzer {
         } else if (originalDependency != null) {
           if (!config.allowVersions() && originalDependency.getVersion() != null) {
             log.warn(String.format("Version tag must be removed for managed dependency %s", dependencyKey));
-            dependencyVersionDisallowed = true;
+            dependencyVersionDisallowedError = true;
             success = false;
           }
 

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
@@ -36,7 +36,7 @@ public class DependencyManagementAnalyzer {
     success &= checkPluginManagement();
 
 
-    if (errorMessages.size() > 0) {
+    if (!errorMessages.isEmpty()) {
       log.warn("");
       for(String msg : errorMessages) {
         log.warn(msg);

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
@@ -15,13 +15,12 @@ public class DependencyManagementAnalyzer {
   private final MavenProject project;
   private final RequireManagement requireManagement;
   private final Log log;
-  private boolean dependencyversionMismatchError = false;
+  private boolean dependencyVersionMismatchError = false;
   private boolean unmanagedDependencyError = false;
   private boolean unmanagedPluginError = false;
-  private boolean pluginversionMismatchError = false;
+  private boolean pluginVersionMismatchError = false;
   private boolean dependencyExclusionsError = false;
   private boolean dependencyVersionDisallowed = false;
-
 
   public DependencyManagementAnalyzer(MavenProject project, RequireManagement requireManagement, Log log) {
     this.project = project;
@@ -33,23 +32,27 @@ public class DependencyManagementAnalyzer {
     boolean success = checkDependencyManagement();
     // don't combine with previous line, we don't want short-circuit evaluation
     success &= checkPluginManagement();
-    log.info("\n\n---- Issues found ----\n");
+
+    log.warn("");
     if (unmanagedDependencyError) {
       log.warn(requireManagement.unmanagedDependencyMessage());
     }
-    if (dependencyversionMismatchError) {
+    if (dependencyVersionMismatchError) {
       log.warn(requireManagement.dependencyVersionMismatchMessage());
     }
     if (unmanagedPluginError) {
-      log.warn(requireManagement.unmanagedPluginMessage()); }
-    if (pluginversionMismatchError) {
+      log.warn(requireManagement.unmanagedPluginMessage());
+    }
+    if (pluginVersionMismatchError) {
       log.warn(requireManagement.pluginVersionMismatchMessage());
     }
     if (dependencyExclusionsError) {
-      log.warn(requireManagement.dependencyExclusionsMessage()); }
+      log.warn(requireManagement.dependencyExclusionsMessage());
+    }
     if (dependencyVersionDisallowed) {
       log.warn(requireManagement.dependencyVersionDisallowedMessage());
     }
+
     return success;
   }
 
@@ -71,7 +74,7 @@ public class DependencyManagementAnalyzer {
         if (!projectVersion.equals(managedVersion)) {
           String errorFormat = "Version mismatch for %s, managed version %s does not match project version %s";
           log.warn(String.format(errorFormat, dependencyKey, managedVersion, projectVersion));
-          dependencyversionMismatchError = true;
+          dependencyVersionMismatchError = true;
           success = false;
         } else if (originalDependency != null) {
           if (!config.allowVersions() && originalDependency.getVersion() != null) {
@@ -92,6 +95,7 @@ public class DependencyManagementAnalyzer {
         success = false;
       }
     }
+
     return success;
   }
 
@@ -110,7 +114,7 @@ public class DependencyManagementAnalyzer {
         if (!projectVersion.equals(managedVersion)) {
           String errorFormat = "Version mismatch for plugin %s, managed version %s does not match project version %s";
           log.warn(String.format(errorFormat, projectPlugin.getKey(), managedVersion, projectVersion));
-          pluginversionMismatchError = true;
+          pluginVersionMismatchError = true;
           success = false;
         }
       } else if (config.requirePluginManagement()) {

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/DependencyManagementAnalyzer.java
@@ -22,8 +22,7 @@ public class DependencyManagementAnalyzer {
   private boolean pluginVersionMismatchError = false;
   private boolean dependencyExclusionsError = false;
   private boolean dependencyVersionDisallowedError = false;
-  private ArrayList<String> errorMessages = new ArrayList<String>();
-  //private String[] errorMessages;
+  private List<String> errorMessages = new ArrayList<String>();
 
   public DependencyManagementAnalyzer(MavenProject project, RequireManagement requireManagement, Log log) {
     this.project = project;
@@ -39,29 +38,10 @@ public class DependencyManagementAnalyzer {
 
     if (errorMessages.size() > 0) {
       log.warn("");
-      for(int msg = 0; msg < errorMessages.size(); msg++) {
-        log.warn(errorMessages.get(msg));
+      for(String msg : errorMessages) {
+        log.warn(msg);
       }
     }
-
-    /*if (unmanagedDependencyError && requireManagement.unmanagedDependencyMessage() != null) {
-      log.warn("Found unmanaged dependencies: "+requireManagement.unmanagedDependencyMessage());
-    }
-    if (dependencyVersionMismatchError && requireManagement.dependencyVersionMismatchMessage() != null) {
-      log.warn("Found version mismatches in managed dependencies: "+requireManagement.dependencyVersionMismatchMessage());
-    }
-    if (unmanagedPluginError && requireManagement.unmanagedPluginMessage() != null) {
-      log.warn("Found unmanaged plugins: "+requireManagement.unmanagedPluginMessage());
-    }
-    if (pluginVersionMismatchError && requireManagement.pluginVersionMismatchMessage() != null) {
-      log.warn("Found version mismatches in plugins: "+requireManagement.pluginVersionMismatchMessage());
-    }
-    if (dependencyExclusionsError && requireManagement.dependencyExclusionsMessage() != null) {
-      log.warn("Found exclusions in managed dependencies: "+requireManagement.dependencyExclusionsMessage());
-    }
-    if (dependencyVersionDisallowedError && requireManagement.dependencyVersionDisallowedMessage() != null) {
-      log.warn("Found version in managed dependencies: "+requireManagement.dependencyVersionDisallowedMessage());
-    }*/
 
     return success;
   }
@@ -107,16 +87,20 @@ public class DependencyManagementAnalyzer {
     }
 
     if (dependencyVersionMismatchError && requireManagement.dependencyVersionMismatchMessage() != null) {
-      errorMessages.add("Found version mismatches in managed dependencies: "+requireManagement.dependencyVersionMismatchMessage());
+      errorMessages.add("Found versions mismatches in managed dependencies:");
+      errorMessages.add("  " + requireManagement.dependencyVersionMismatchMessage());
     }
     if (dependencyVersionDisallowedError && requireManagement.dependencyVersionDisallowedMessage() != null) {
-      errorMessages.add("Found version in managed dependencies: "+requireManagement.dependencyVersionDisallowedMessage());
+      errorMessages.add("Found version in managed dependencies:");
+      errorMessages.add("  " + requireManagement.dependencyVersionDisallowedMessage());
     }
     if (dependencyExclusionsError && requireManagement.dependencyExclusionsMessage() != null) {
-      errorMessages.add("Found exclusions in managed dependencies: "+requireManagement.dependencyExclusionsMessage());
+      errorMessages.add("Found exclusions in managed dependencies:");
+      errorMessages.add("  " + requireManagement.dependencyExclusionsMessage());
     }
     if (unmanagedDependencyError && requireManagement.unmanagedDependencyMessage() != null) {
-      errorMessages.add("Found unmanaged dependencies: "+requireManagement.unmanagedDependencyMessage());
+      errorMessages.add("Found unmanaged dependencies:");
+      errorMessages.add("  " + requireManagement.unmanagedDependencyMessage());
     }
     return success;
   }
@@ -146,10 +130,12 @@ public class DependencyManagementAnalyzer {
       }
     }
     if (pluginVersionMismatchError && requireManagement.pluginVersionMismatchMessage() != null) {
-      errorMessages.add("Found version mismatches in plugins: "+requireManagement.pluginVersionMismatchMessage());
+      errorMessages.add("Found version mismatches in plugins:");
+      errorMessages.add("  " + requireManagement.pluginVersionMismatchMessage());
     }
     if (unmanagedPluginError && requireManagement.unmanagedPluginMessage() != null) {
-      errorMessages.add("Found unmanaged plugins: "+requireManagement.unmanagedPluginMessage());
+      errorMessages.add("Found unmanaged plugins:");
+      errorMessages.add("  " + requireManagement.unmanagedPluginMessage());
     }
 
     return success;

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagement.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagement.java
@@ -8,6 +8,13 @@ public class RequireManagement implements RequireManagmentConfig {
   private boolean plugins = false;
   private boolean allowVersions = true;
   private boolean allowExclusions = true;
+  private String unManagedDependencyMessage = null;
+  private String dependencyVersionMismatchMessage = null;
+  private String unManagedPluginMessage = null;
+  private String pluginVersionMismatchMessage = null;
+  private String dependencyExclusionsMessage = null;
+  private String dependencyVersionDisallowedMessage = null;
+
   private List<RequireManagementOverride> overrides = new ArrayList<>();
 
   @Override
@@ -52,5 +59,59 @@ public class RequireManagement implements RequireManagmentConfig {
 
   public void setOverrides(List<RequireManagementOverride> overrides) {
     this.overrides = overrides;
+  }
+
+  @Override
+  public String unManagedDependencyMessage() {
+    return unManagedDependencyMessage;
+  }
+
+  public void setunManagedDependencyMessage(String unManagedDependencyMessage) {
+    this.unManagedDependencyMessage = unManagedDependencyMessage;
+  }
+
+  @Override
+  public String dependencyVersionMismatchMessage() {
+    return dependencyVersionMismatchMessage;
+  }
+
+  public void setDependencyVersionMismatchMessage(String dependencyVersionMismatchMessage) {
+    this.dependencyVersionMismatchMessage = dependencyVersionMismatchMessage;
+  }
+
+  @Override
+  public String unManagedPluginMessage() {
+    return unManagedPluginMessage;
+  }
+
+  public void setUnManagedPluginMessage(String unManagedPluginMessage) {
+    this.unManagedPluginMessage = unManagedPluginMessage;
+  }
+
+  @Override
+  public String pluginVersionMismatchMessage() {
+    return pluginVersionMismatchMessage;
+  }
+
+  public void setPluginVersionMismatchMessage(String pluginVersionMismatchMessage) {
+    this.pluginVersionMismatchMessage = pluginVersionMismatchMessage;
+  }
+
+  @Override
+  public String dependencyExclusionsMessage() {
+    return dependencyExclusionsMessage;
+  }
+
+  public void setDependencyExclusionsMessage(String dependencyExclusionsMessage) {
+    this.dependencyExclusionsMessage = dependencyExclusionsMessage;
+  }
+
+  @Override
+  public String dependencyVersionDisallowedMessage() {
+    return dependencyVersionDisallowedMessage;
+  }
+
+  public void setdependencyVersionDisallowedMessage(String dependencyVersionDisallowedMessage) {
+    this.dependencyVersionDisallowedMessage = dependencyVersionDisallowedMessage;
   }
 }

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagement.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagement.java
@@ -8,9 +8,9 @@ public class RequireManagement implements RequireManagmentConfig {
   private boolean plugins = false;
   private boolean allowVersions = true;
   private boolean allowExclusions = true;
-  private String unManagedDependencyMessage = null;
+  private String unmanagedDependencyMessage = null;
   private String dependencyVersionMismatchMessage = null;
-  private String unManagedPluginMessage = null;
+  private String unmanagedPluginMessage = null;
   private String pluginVersionMismatchMessage = null;
   private String dependencyExclusionsMessage = null;
   private String dependencyVersionDisallowedMessage = null;
@@ -62,12 +62,12 @@ public class RequireManagement implements RequireManagmentConfig {
   }
 
   @Override
-  public String unManagedDependencyMessage() {
-    return unManagedDependencyMessage;
+  public String unmanagedDependencyMessage() {
+    return unmanagedDependencyMessage;
   }
 
-  public void setunManagedDependencyMessage(String unManagedDependencyMessage) {
-    this.unManagedDependencyMessage = unManagedDependencyMessage;
+  public void setUnmanagedDependencyMessage(String unmanagedDependencyMessage) {
+    this.unmanagedDependencyMessage = unmanagedDependencyMessage;
   }
 
   @Override
@@ -80,12 +80,12 @@ public class RequireManagement implements RequireManagmentConfig {
   }
 
   @Override
-  public String unManagedPluginMessage() {
-    return unManagedPluginMessage;
+  public String unmanagedPluginMessage() {
+    return unmanagedPluginMessage;
   }
 
-  public void setUnManagedPluginMessage(String unManagedPluginMessage) {
-    this.unManagedPluginMessage = unManagedPluginMessage;
+  public void setUnmanagedPluginMessage(String unmanagedPluginMessage) {
+    this.unmanagedPluginMessage = unmanagedPluginMessage;
   }
 
   @Override

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagement.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagement.java
@@ -111,7 +111,7 @@ public class RequireManagement implements RequireManagmentConfig {
     return dependencyVersionDisallowedMessage;
   }
 
-  public void setdependencyVersionDisallowedMessage(String dependencyVersionDisallowedMessage) {
+  public void setDependencyVersionDisallowedMessage(String dependencyVersionDisallowedMessage) {
     this.dependencyVersionDisallowedMessage = dependencyVersionDisallowedMessage;
   }
 }

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
@@ -55,6 +55,37 @@ public class RequireManagementOverride {
       public boolean allowExclusions() {
         return fallbackIfNull(allowExclusions, requireManagement.allowExclusions());
       }
+
+      @Override
+      public String unManagedDependencyMessage() {
+        return null;
+      }
+
+      @Override
+      public String dependencyVersionMismatchMessage() {
+        return null;
+      }
+
+      @Override
+      public String unManagedPluginMessage() {
+        return null;
+      }
+
+      @Override
+      public String pluginVersionMismatchMessage() {
+        return null;
+      }
+
+      @Override
+      public String dependencyExclusionsMessage() {
+        return null;
+      }
+
+      @Override
+      public String dependencyVersionDisallowedMessage() {
+        return null;
+      }
+
     };
   }
 

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
@@ -85,7 +85,6 @@ public class RequireManagementOverride {
       public String dependencyVersionDisallowedMessage() {
         return requireManagement.dependencyVersionDisallowedMessage();
       }
-
     };
   }
 

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagementOverride.java
@@ -57,33 +57,33 @@ public class RequireManagementOverride {
       }
 
       @Override
-      public String unManagedDependencyMessage() {
-        return null;
+      public String unmanagedDependencyMessage() {
+        return requireManagement.unmanagedDependencyMessage();
       }
 
       @Override
       public String dependencyVersionMismatchMessage() {
-        return null;
+        return requireManagement.dependencyVersionMismatchMessage();
       }
 
       @Override
-      public String unManagedPluginMessage() {
-        return null;
+      public String unmanagedPluginMessage() {
+        return requireManagement.unmanagedPluginMessage();
       }
 
       @Override
       public String pluginVersionMismatchMessage() {
-        return null;
+        return requireManagement.pluginVersionMismatchMessage();
       }
 
       @Override
       public String dependencyExclusionsMessage() {
-        return null;
+        return requireManagement.dependencyExclusionsMessage();
       }
 
       @Override
       public String dependencyVersionDisallowedMessage() {
-        return null;
+        return requireManagement.dependencyVersionDisallowedMessage();
       }
 
     };

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagmentConfig.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagmentConfig.java
@@ -5,9 +5,9 @@ public interface RequireManagmentConfig {
   boolean requirePluginManagement();
   boolean allowVersions();
   boolean allowExclusions();
-  String unManagedDependencyMessage();
+  String unmanagedDependencyMessage();
   String dependencyVersionMismatchMessage();
-  String unManagedPluginMessage();
+  String unmanagedPluginMessage();
   String pluginVersionMismatchMessage();
   String dependencyExclusionsMessage();
   String dependencyVersionDisallowedMessage();

--- a/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagmentConfig.java
+++ b/src/main/java/com/hubspot/maven/plugins/dependency/management/RequireManagmentConfig.java
@@ -5,4 +5,10 @@ public interface RequireManagmentConfig {
   boolean requirePluginManagement();
   boolean allowVersions();
   boolean allowExclusions();
+  String unManagedDependencyMessage();
+  String dependencyVersionMismatchMessage();
+  String unManagedPluginMessage();
+  String pluginVersionMismatchMessage();
+  String dependencyExclusionsMessage();
+  String dependencyVersionDisallowedMessage();
 }


### PR DESCRIPTION
This PR provides support to pass custom error messages for the following errors -
- dependency version doesn't match dependencyManagement version
- dependency has version tag, and version tags are disallowed
- dependency has exclusions, and exclusions are disallowed
- dependency is not in dependencyManagement
- plugin version doesn't match pluginManagement version
- plugin is not in pluginManagement